### PR TITLE
Fix incremental output

### DIFF
--- a/tlog.go
+++ b/tlog.go
@@ -46,6 +46,7 @@ func main() {
 			fmt.Printf("%2.3f %s\n", time.Since(startTime).Seconds(), text)
 		} else if incremental == true {
 			fmt.Printf("%2.3f %s\n", time.Since(prevTime).Seconds(), text)
+			prevTime = time.Now()
 		} else {
 			now := time.Now()
 			fmt.Printf("%s %s\n", strftime.Format(format, now), text)


### PR DESCRIPTION
The incremental output was identical to the relative output. This PR correctly implements incremental timestamps.